### PR TITLE
Remove UseBiasedLocking

### DIFF
--- a/amundsen/etc/jvm.config
+++ b/amundsen/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/delta-lake/etc/jvm.config
+++ b/delta-lake/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/dolphinscheduler/etc/jvm.config
+++ b/dolphinscheduler/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/druid/trino-druid/etc/jvm.config
+++ b/druid/trino-druid/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/elasticsearch/trino-elasticsearch7/etc/jvm.config
+++ b/elasticsearch/trino-elasticsearch7/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/hive/trino-b2/etc/jvm.config
+++ b/hive/trino-b2/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx2G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/hive/trino-hdfs3/etc/jvm.config
+++ b/hive/trino-hdfs3/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/hive/trino-minio/etc/jvm.config
+++ b/hive/trino-minio/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/hudi/trino-hudi-minio/etc/jvm.config
+++ b/hudi/trino-hudi-minio/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/iceberg/trino-alluxio-iceberg-minio/etc/jvm.config
+++ b/iceberg/trino-alluxio-iceberg-minio/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/kafka/trino-kafka/etc/jvm.config
+++ b/kafka/trino-kafka/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/lakefs/trino-lakefs-minio/etc/jvm.config
+++ b/lakefs/trino-lakefs-minio/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/mongo/trino-mongo/etc/jvm.config
+++ b/mongo/trino-mongo/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/pinot/trino-pinot/etc/jvm.config
+++ b/pinot/trino-pinot/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/zeppelin/etc/jvm.config
+++ b/zeppelin/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent


### PR DESCRIPTION
This removes the `UseBiasedLocking` from `jvm.config` files.

Fixes #36.

See also #42.

It probably also makes sense to do a more complete update of the `jvm.config` and to peg the `trinodb/trino` docker image to a specific tag.