### PR TITLE
Use Apache Hive 4.0.0 and latest Trino/MariaDB

### DIFF
--- a/hive/trino-b2/README.md
+++ b/hive/trino-b2/README.md
@@ -32,7 +32,7 @@ the Docker images before you see the "done" message):
 ```
 [+] Running 5/5
  ✔ Network trino-b2_trino-network          Created  0.0s 
- ✔ Volume "trino-b2_maria-volume"          Created  0.0s 
+ ✔ Volume "trino-b2_maria_volume"          Created  0.0s 
  ✔ Container trino-b2-mariadb-1            Started  0.4s 
  ✔ Container trino-b2-trino-coordinator-1  Started  0.4s 
  ✔ Container trino-b2-hive-metastore-1     Started  0.7s

--- a/hive/trino-b2/docker-compose.yml
+++ b/hive/trino-b2/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - '8080:8080'
     volumes:
       - ./etc:/etc/trino
-      - ./cache:/opt/hive-cache
     networks:
       - trino-network
 
@@ -27,14 +26,17 @@ services:
       - trino-network
 
   hive-metastore:
-    image: 'bitsondatadev/hive-metastore:latest'
+    image: 'apache/hive:4.0.0'
     hostname: hive-metastore
     ports:
       - '9083:9083' # Metastore Thrift
     volumes:
-      - ./conf/metastore-site.xml:/opt/apache-hive-metastore-3.0.0-bin/conf/metastore-site.xml:ro
+      - ./conf/core-site.xml:/opt/hadoop/etc/hadoop/core-site.xml:ro
+      - ./conf/metastore-site.xml:/opt/apache-hive-metastore-4.0.0-bin/conf/metastore-site.xml:ro
     environment:
+      SERVICE_NAME: metastore
       METASTORE_DB_HOSTNAME: mariadb
+      HIVE_AUX_JARS_PATH: /opt/hadoop/share/hadoop/tools/lib/hadoop-aws-3.3.6.jar:/opt/hadoop/share/hadoop/tools/lib/aws-java-sdk-bundle-1.12.367.jar
     depends_on:
       - mariadb
     networks:

--- a/hive/trino-b2/etc/catalog/b2.properties
+++ b/hive/trino-b2/etc/catalog/b2.properties
@@ -5,11 +5,5 @@ hive.s3.endpoint=ENDPOINT
 hive.s3.aws-access-key=KEY_ID
 hive.s3.aws-secret-key=APPLICATION_KEY
 hive.non-managed-table-writes-enabled=true
-hive.s3select-pushdown.enabled=false
 hive.storage-format=PARQUET
 hive.recursive-directories=true
-
-# hive.cache.enabled=true
-# hive.cache.location=/opt/hive-cache
-
-hive.allow-drop-table=true

--- a/hive/trino-b2/etc/jvm.config
+++ b/hive/trino-b2/etc/jvm.config
@@ -9,3 +9,8 @@
 -XX:ReservedCodeCacheSize=256M
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+# Allow loading dynamic agent used by JOL
+-XX:+EnableDynamicAgentLoading
+-XX:+UnlockDiagnosticVMOptions
+# https://bugs.openjdk.org/browse/JDK-8329528
+-XX:G1NumCollectionsKeepPinned=10000000


### PR DESCRIPTION
Changes to make the `trino-b2` tutorial work with Apache Hive 4.0.0 and latest Trino/MariaDB:

* Move from @bitsondatadev's custom `hive-metastore` image to `apache/hive:4.0.0`.
* Remove defunct Hive connector parameters.
* Update `jvm.config`.